### PR TITLE
fix: changed the gestureEnabled property to false. 

### DIFF
--- a/src/navigation/RootNavigation.tsx
+++ b/src/navigation/RootNavigation.tsx
@@ -64,7 +64,7 @@ export default function RootNavigation() {
 
   const stackNavOption: StackNavigationOptions = {
     headerShown: false,
-    gestureEnabled: true,
+    gestureEnabled: false,
   };
 
   function navOnReady() {


### PR DESCRIPTION
this was left to `true` because i forgot to change it back when i was testing some stuff.
this is now changed to false because it was causing pages to not be swipable